### PR TITLE
Fixes exporting resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 .DS_Store
 .env
 static/
+.idea
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ info gatsby serve running at: http://localhost:9000/
 
 ### Configuration 🛠
 
-| Name         | Description                     | Required | Default Value |
-| ------------ | ------------------------------- | -------- | ------------- |
-| `resumeJson` | Data for resume                 | `true`   |               |
-| `theme`      | Theme to be used in JSONResume  | `false`  | `"flat"`      |
-| `name`       | Name/Route for the resulting CV | `false`  | `"resume"`    |
+| Name         | Description                     | Required | Default Value                  |
+| ------------ | ------------------------------- | -------- | ------------------------------ |
+| `resumeJson` | Data for resume                 | `true`   |                                |
+| `theme`      | Theme to be used in JSONResume  | `false`  | `"jsonresume-theme-flat"`      |
+| `name`       | Name/Route for the resulting CV | `false`  | `"resume"`                     |
 
 #### Using a different Theme 🌈
 
@@ -87,7 +87,7 @@ module.exports = {
       resolve: `gatsby-theme-jsonresume`,
       options: {
         resumeJson: { // ...JSON Resume Schema },
-        theme: 'orbit',
+        theme: 'jsonresume-theme-orbit',
       },
     },
   ],

--- a/gatsby-starter-jsonresume/gatsby-config.js
+++ b/gatsby-starter-jsonresume/gatsby-config.js
@@ -14,7 +14,7 @@ module.exports = {
       options: {
         resumeJson,
         name: 'resume-custom-theme',
-        theme: 'standard-resume',
+        theme: 'jsonresume-theme-standard-resume',
       },
     },
     {

--- a/gatsby-theme-jsonresume/gatsby-node.js
+++ b/gatsby-theme-jsonresume/gatsby-node.js
@@ -1,19 +1,15 @@
-const { exportResume } = require('resume-cli/lib');
+const exportResume = require('resume-cli/build/export-resume');
 const { existsSync, mkdirSync, renameSync } = require('fs');
 
-const exportPromise = ({ format, theme, name, resumeJson }) =>
-  new Promise((resolve, reject) => {
-    exportResume(
-      resumeJson,
-      name,
-      {
-        format,
-        theme,
-        dir: __dirname,
-      },
-      (error) => (error ? reject(error) : resolve()),
-    );
-  });
+const exportPromise = ({ format, theme, fileName, resume }) =>
+    new Promise((resolve, reject) => {
+        exportResume({
+            format,
+            theme,
+            fileName,
+            resume,
+        }, (error) => (error ? reject(error) : resolve()))
+    });
 
 const moveToStatic = (file) => {
   if (!existsSync('static/')) mkdirSync('static');
@@ -29,11 +25,11 @@ const moveToStatic = (file) => {
  */
 module.exports.createPages = async (
   _,
-  { resumeJson, theme = 'flat', name = 'resume' },
+  { resumeJson, theme = 'jsonresume-theme-flat', name = 'resume' },
 ) => {
   await Promise.all(
     ['html', 'pdf'].map(async (format) => {
-      await exportPromise({ format, resumeJson, theme, name });
+      await exportPromise({ format, resume: resumeJson, theme, fileName: name });
       moveToStatic(`${name}.${format}`);
     }),
   );

--- a/gatsby-theme-jsonresume/package.json
+++ b/gatsby-theme-jsonresume/package.json
@@ -21,7 +21,8 @@
     "gatsby": "^3.0.0"
   },
   "dependencies": {
-    "resume-cli": "^3.0.5"
+    "resume-cli": "~3.0.5",
+    "jsonresume-theme-flat": "~0.3.7"
   },
   "resolutions": {
     "html-to-text": "7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8288,7 +8288,7 @@ jsonresume-theme-even@^0.6.0:
     micromark "^2.11.4"
     striptags "^3.1.1"
 
-jsonresume-theme-flat@^0.3.7:
+jsonresume-theme-flat@^0.3.7, jsonresume-theme-flat@~0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/jsonresume-theme-flat/-/jsonresume-theme-flat-0.3.7.tgz#a264f00d6c5850dd7c4b5c15d64204d213a85552"
   integrity sha1-omTwDWxYUN18S1wV1kIE0hOoVVI=
@@ -11022,7 +11022,7 @@ resume-cli@^1.2.7:
     z-schema "^4.2.2"
     z-schema-errors "^0.2.1"
 
-resume-cli@^3.0.5:
+resume-cli@~3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/resume-cli/-/resume-cli-3.0.5.tgz#c9f7d8eb2684ec7ee4b30571ad0575004cd4fb3f"
   integrity sha512-C5/LyLv0wcwg46pL3b/AzwMBpYCwa/FiAt13tBUfZQ1JgJshWYaB5TF3NH1Evlfhb6VpCvSXw+FY4By83pflCA==


### PR DESCRIPTION
I encountered several errors when trying to use this plugin for my gatsby project.
ATM the example project is also broken.

This PR fixes the following: 

- Incorrect `resume-cli` require path.
- Pass correct object to `exportResume` function. [Line 11](https://github.com/jsonresume/resume-cli/blob/master/lib/export-resume.js#L11)
- Full `theme` name should be used instead of only suffix. [Line 55](https://github.com/jsonresume/resume-cli/blob/master/lib/export-resume.js#L55)